### PR TITLE
[METRICS-2172]check actual contents of exported metric

### DIFF
--- a/export/http_test.go
+++ b/export/http_test.go
@@ -54,7 +54,7 @@ func TestHTTPExportMetrics(t *testing.T) {
 
 		want, err := proto.Marshal(metricsRequest)
 		if err != nil {
-			log.Fatal("Marshalling error: ", err)
+			t.Errorf("Marshalling error: %v", err)
 		}
 
 		if res := bytes.Compare(got, want); res != 0 {

--- a/export/http_test.go
+++ b/export/http_test.go
@@ -54,7 +54,7 @@ func TestHTTPExportMetrics(t *testing.T) {
 
 		want, err := proto.Marshal(metricsRequest)
 		if err != nil {
-			t.Errorf("Marshalling error: %v", err)
+			t.Fatalf("Marshalling error: %v", err)
 		}
 
 		if res := bytes.Compare(got, want); res != 0 {

--- a/export/kakfa_test.go
+++ b/export/kakfa_test.go
@@ -141,7 +141,10 @@ func TestKafkaExportMetrics(t *testing.T) {
 	}
 
 	topics := []string{topicName}
-	consumer.SubscribeTopics(topics, nil)
+	if err = consumer.SubscribeTopics(topics, nil); err != nil {
+		t.Errorf("Couldn't subscribe to topic: %v", err)
+	}
+
 	message, err := consumer.ReadMessage(10 * time.Second)
 	if err != nil {
 		t.Errorf("Kafka Export Metrics Failed, couldn't consume message: %v", err)
@@ -152,7 +155,9 @@ func TestKafkaExportMetrics(t *testing.T) {
 		}
 
 		got := &v1.Metric{}
-		proto.Unmarshal(message.Value, got)
+		if err = proto.Unmarshal(message.Value, got); err != nil {
+			t.Errorf("Error unmarshalling consumed message: %v", err)
+		}
 
 		if !reflect.DeepEqual(want.MetricDescriptor, got.MetricDescriptor) {
 			t.Errorf("consumed metric and sent metric descriptor not equal for kafka export, expected val %v, got %v",

--- a/export/kakfa_test.go
+++ b/export/kakfa_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
+	v1 "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -26,9 +29,17 @@ var (
 	topicName        = "test"
 	newFlushTime     = 20
 	defaultFlushTime = 15
+	listenerIP       = "127.0.0.1"
+	bootstrapServer  = listenerIP + ":" + kafkaPort
 
 	kafkaConfig = &kafka.ConfigMap{
-		"bootstrap.servers": "localhost:9092",
+		"bootstrap.servers": bootstrapServer,
+	}
+
+	consumerConfig = &kafka.ConfigMap{
+		"bootstrap.servers": bootstrapServer,
+		"group.id":          "my-group",
+		"auto.offset.reset": "earliest",
 	}
 
 	topicInfo = TopicConfig{
@@ -123,6 +134,40 @@ func TestKafkaExportMetrics(t *testing.T) {
 	if err != nil {
 		t.Errorf("Kafka Export Metrics Failed, couldn't export metrics: %v", err)
 	}
+
+	consumer, err := kafka.NewConsumer(consumerConfig)
+	if err != nil {
+		t.Errorf("Failed to create new Kafka Consumer: %v", err)
+	}
+
+	topics := []string{topicName}
+	consumer.SubscribeTopics(topics, nil)
+	message, err := consumer.ReadMessage(10 * time.Second)
+	if err != nil {
+		t.Errorf("Kafka Export Metrics Failed, couldn't consume message: %v", err)
+	} else {
+		want, err := metricToProto(metric)
+		if err != nil {
+			t.Errorf("Error converting metric to Proto: %v", err)
+		}
+
+		got := &v1.Metric{}
+		proto.Unmarshal(message.Value, got)
+
+		if !reflect.DeepEqual(want.MetricDescriptor, got.MetricDescriptor) {
+			t.Errorf("consumed metric and sent metric descriptor not equal for kafka export, expected val %v, got %v",
+				want.MetricDescriptor,
+				got.MetricDescriptor)
+		}
+
+		if !reflect.DeepEqual(want.Timeseries, got.Timeseries) {
+			t.Errorf("consumed metric and sent metric timeseries not equal for kafka export, expected val %v, got %v",
+				want.Timeseries,
+				got.Timeseries)
+		}
+	}
+
+	consumer.Close()
 }
 
 func createDockerNetwork(t *testing.T, networkName string) (*client.Client, types.NetworkCreateResponse) {
@@ -186,7 +231,7 @@ func startKafkaContainer(
 		Networks:     []string{network},
 		Env: map[string]string{
 			"KAFKA_BROKER_ID":                                  "1",
-			"KAFKA_ADVERTISED_LISTENERS":                       "PLAINTEXT_HOST://localhost:" + port,
+			"KAFKA_ADVERTISED_LISTENERS":                       "PLAINTEXT_HOST://" + listenerIP + ":" + port,
 			"KAFKA_ZOOKEEPER_CONNECT":                          zookeeperContainerName + ":" + zookeeperPort,
 			"KAFKA_LISTENER_SECURITY_PROTOCOL_MAP":             "PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT",
 			"KAFKA_INTER_BROKER_LISTENER_NAME":                 "PLAINTEXT_HOST",

--- a/export/metric_to_pb_test.go
+++ b/export/metric_to_pb_test.go
@@ -97,7 +97,7 @@ func TestMetricToPointInt64(t *testing.T) {
 	}
 	got, err := metricToPoints(&timeseries)
 	if err != nil {
-		t.Errorf("Error converting metric to timeseries proto: %v", err)
+		t.Fatalf("Error converting metric to timeseries proto: %v", err)
 	}
 	comparePoints(t, intPoints, got)
 }
@@ -108,7 +108,7 @@ func TestMetricToPointDouble64(t *testing.T) {
 	}
 	got, err := metricToPoints(&timeseries)
 	if err != nil {
-		t.Errorf("Error converting metric to timeseries proto: %v", err)
+		t.Fatalf("Error converting metric to timeseries proto: %v", err)
 	}
 	comparePoints(t, doublePoints, got)
 }
@@ -133,7 +133,7 @@ func TestMetricToPointSummary(t *testing.T) {
 
 	got, err := metricToPoints(&timeseries)
 	if err != nil {
-		t.Errorf("Error converting metric to timeseries proto: %v", err)
+		t.Fatalf("Error converting metric to timeseries proto: %v", err)
 	}
 	comparePoints(t, summaryPoints, got)
 }
@@ -146,7 +146,7 @@ func TestMetricToLabelValues(t *testing.T) {
 func TestMetricToTimeSeries(t *testing.T) {
 	got, err := metricToTimeSeries(metric)
 	if err != nil {
-		t.Errorf("Error converting metric to timeseries proto: %v", err)
+		t.Fatalf("Error converting metric to timeseries proto: %v", err)
 	}
 	compareMetricTimeseries(t, timeseriesProto, got)
 }
@@ -183,7 +183,7 @@ func TestMetricToLabelKeys(t *testing.T) {
 func TestMetricToProto(t *testing.T) {
 	got, err := metricToProto(metric)
 	if err != nil {
-		t.Errorf("Error converting metric to proto")
+		t.Fatalf("Error converting metric to proto: %v", err)
 	}
 	compareMetricTimeseries(t, dummyMetricProto.Timeseries, got.Timeseries)
 	compareMetricDesc(t, dummyMetricProto.GetMetricDescriptor(), got.GetMetricDescriptor())
@@ -192,7 +192,7 @@ func TestMetricToProto(t *testing.T) {
 func TestMetricToServiceRequest(t *testing.T) {
 	got, err := metricsToServiceRequest(metrics)
 	if err != nil {
-		t.Errorf("Error converting metrics to service proto ")
+		t.Fatalf("Error converting metrics to service proto: %v", err)
 	}
 	for i := range dummyServiceRequestProto.Metrics {
 		compareMetricTimeseries(t, dummyServiceRequestProto.Metrics[i].Timeseries, got.Metrics[i].Timeseries)
@@ -202,7 +202,7 @@ func TestMetricToServiceRequest(t *testing.T) {
 
 func comparePoints(t *testing.T, want []*v1.Point, got []*v1.Point) {
 	if len(want) != len(got) {
-		t.Errorf("Metric to Points int failed, expected length %v, got %v", len(want), len(got))
+		t.Fatalf("Metric to Points int failed, expected length %v, got %v", len(want), len(got))
 	}
 
 	for i := range want {
@@ -229,7 +229,7 @@ func comparePoints(t *testing.T, want []*v1.Point, got []*v1.Point) {
 
 func compareLabelVals(t *testing.T, want []*v1.LabelValue, got []*v1.LabelValue) {
 	if len(want) != len(got) {
-		t.Errorf("Metric to Label Values failed, expected length %v, got %v", len(want), len(got))
+		t.Fatalf("Metric to Label Values failed, expected length %v, got %v", len(want), len(got))
 	}
 
 	for i := range want {
@@ -255,6 +255,10 @@ func compareMetricTimeseries(t *testing.T, want []*v1.TimeSeries, got []*v1.Time
 }
 
 func compareLabelKeys(t *testing.T, want []*v1.LabelKey, got []*v1.LabelKey) {
+	if len(want) != len(got) {
+		t.Fatalf("Metric to Label Key failed, expected length %v, got %v", len(want), len(got))
+	}
+
 	for i := range want {
 		if want[i].GetKey() != got[i].GetKey() {
 			t.Errorf("Metric to Label Key failed, expected key %v, got %v", want[i].GetKey(), got[i].GetKey())


### PR DESCRIPTION
this PR adds on to the KafkaExportMetric test and spins up a consumer to confirm the contents of the message sent